### PR TITLE
feat: added transitive dependencies

### DIFF
--- a/packages/models.py
+++ b/packages/models.py
@@ -1,6 +1,12 @@
 class VersionedPackage:
-    def __init__(self, name: str, version: str, description: str, dependencies: list[tuple]):
+    def __init__(
+        self,
+        name: str,
+        version: str,
+        description: str,
+        dependencies: list["VersionedPackage"] | None = None
+    ):
         self.name = name
         self.version = version
         self.description = description
-        self.dependencies = dependencies
+        self.dependencies = dependencies or []

--- a/packages/modules/npm.py
+++ b/packages/modules/npm.py
@@ -1,21 +1,44 @@
 import requests
+import semver
 
 from packages.models import VersionedPackage
 
 NPM_REGISTRY_URL = "https://registry.npmjs.org"
 
 
-def get_versioned_package(name: str, version: str) -> VersionedPackage:
-    url = f"{NPM_REGISTRY_URL}/{name}/{version}"
+def get_package(name: str, range: str) -> VersionedPackage:
+    url = f"{NPM_REGISTRY_URL}/{name}"
 
-    response = requests.get(url)
-    npm_package = response.json()
+    npm_package = requests.get(url).json()
+    versions = list(npm_package["versions"].keys())
+    version = semver.min_satisfying(versions, range)
+    version_record = npm_package["versions"][version]
 
     package = VersionedPackage(
-        name=npm_package["name"],
-        description=npm_package["description"],
-        version=npm_package["version"],
-        dependencies=npm_package["dependencies"],
+        name=version_record["name"],
+        version=version_record["version"],
+        description=version_record["description"],
     )
+    dependencies = version_record.get("dependencies", {})
+
+    package.dependencies = [
+        get_package(name=dep_name, range=dep_range) for dep_name, dep_range in dependencies.items()
+    ]
 
     return package
+
+
+def request_package(name: str, range: str) -> tuple[VersionedPackage, dict]:
+    url = f"{NPM_REGISTRY_URL}/{name}"
+
+    npm_package = requests.get(url).json()
+
+    versions = list(npm_package["versions"].keys())
+    version = semver.min_satisfying(versions, range)
+    version_record = npm_package["versions"][version]
+
+    return VersionedPackage(
+        name=version_record["name"],
+        version=version_record["version"],
+        description=version_record["description"],
+    ), version_record.get("dependencies", {})

--- a/packages/serializers.py
+++ b/packages/serializers.py
@@ -1,8 +1,8 @@
 from rest_framework import serializers
+from rest_framework_recursive.fields import RecursiveField
 
 
-class VersionedPackageSerializer(serializers.Serializer):
+class PackageSerializer(serializers.Serializer):
     name = serializers.CharField(required=True)
-    description = serializers.CharField(required=True, allow_null=True)
     version = serializers.CharField()
-    dependencies = serializers.DictField(child=serializers.CharField())
+    dependencies = serializers.ListSerializer(child=RecursiveField())

--- a/packages/urls.py
+++ b/packages/urls.py
@@ -4,5 +4,5 @@ from packages import views
 
 urlpatterns = [
     path("<str:package_name>", views.PackageView.as_view()),
-    path("<str:package_name>/<str:version>", views.PackageView.as_view()),
+    path("<str:package_name>/<str:range>", views.PackageView.as_view()),
 ]

--- a/packages/views.py
+++ b/packages/views.py
@@ -3,13 +3,16 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from packages.modules import npm
-from packages.serializers import VersionedPackageSerializer
+from packages.serializers import PackageSerializer
 
 
 class PackageView(views.APIView):
     renderer_classes = [renderers.JSONRenderer]
 
-    def get(self, request: Request, package_name: str, version: str):
-        package_info = npm.get_versioned_package(package_name, version)
-        serializer = VersionedPackageSerializer(package_info)
+    def get(self, request: Request, package_name: str, range: str | None = None):
+        if range is None:
+            range = "*"
+
+        package_info = npm.get_package(package_name, range)
+        serializer = PackageSerializer(package_info)
         return Response(serializer.data)

--- a/poetry.lock
+++ b/poetry.lock
@@ -220,6 +220,22 @@ django = ">=3.0"
 pytz = "*"
 
 [[package]]
+name = "djangorestframework-recursive"
+version = "0.1.2"
+description = "Recursive Serialization for Django REST framework"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "djangorestframework-recursive-0.1.2.tar.gz", hash = "sha256:f8fc2d677ccb32fe53ec4153a45f66c822d0ce444824cba56edc76ca89b704ae"},
+    {file = "djangorestframework_recursive-0.1.2-py2.py3-none-any.whl", hash = "sha256:e4e51b26b7ee3c9f9b838885d638b91293e7c66e85b5955f278a6e10eb34ce7c"},
+]
+
+[package.dependencies]
+Django = "*"
+djangorestframework = ">=3.0"
+
+[[package]]
 name = "executing"
 version = "2.0.1"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -665,4 +681,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "1757d5def05d9b2c3fca5796e0182c2e28937d036639a99780e89bf086ca3906"
+content-hash = "99a91b23278fd68ca8ddb1e83bf199f08cdc25050997a277c7928a7b42e57c32"

--- a/project/settings.py
+++ b/project/settings.py
@@ -123,3 +123,17 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "INFO",
+    },
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ node-semver = "^0.8.1"
 django = "^4.2.7"
 psycopg2 = "^2.9.9"
 djangorestframework = "^3.14.0"
+djangorestframework-recursive = "^0.1.2"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "^8.17.2"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -3,11 +3,19 @@ from django.test import Client
 
 def test_get_package():
     client = Client()
-    response = client.get("/package/express/2.0.0")
+    response = client.get("/package/minimatch/3.1.2")
     assert response.status_code == 200
     assert response.json() == {
-        "dependencies": {"connect": ">= 1.1.0 < 2.0.0", "mime": ">= 0.0.1", "qs": ">= 0.0.6"},
-        "name": "express",
-        "version": "2.0.0",
-        'description': 'Sinatra inspired web development framework',
+        "dependencies": [
+            {
+                "dependencies": [
+                    {"dependencies": [], "name": "balanced-match", "version": "1.0.2"},
+                    {"dependencies": [], "name": "concat-map", "version": "0.0.1"},
+                ],
+                "name": "brace-expansion",
+                "version": "1.1.11",
+            }
+        ],
+        "name": "minimatch",
+        "version": "3.1.2",
     }


### PR DESCRIPTION
In order to extend our vulnerability scanning feature to support child dependencies for [npm packages](https://docs.npmjs.com/cli/v6/configuring-npm/package-json) as described in https://github.com/snyk/snyk-code-review-exercise/issues/5 , this pull request updates the package service to return all nested dependencies on the internal /package endpoint for consumption by vulnerability service instead of just returning the versions for the first level.

It supports a GET request to the /package/:name/:version endpoint and will return a JSON structure representing the full tree of dependencies. We will always return the latest matching version of a package supported to mimic the behavior of a fresh npm install.

Testing

It can be tested locally by making a request for a package with sub-dependencies e.g. react@16.13.0

```
curl -s http://localhost:3000/package/react/16.13.0 | jq .
```

Related Ticket:

https://github.com/snyk/snyk-code-review-exercise/issues/5